### PR TITLE
Add support for different driver and exe path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ Set "isp" to your ISP's twitter handle.
 | Frontier | @FrontierCorp |  
 ###### Log:  
 Change the name / location of the .log file. Default location is local directory  
+###### Selenium Driver
+Change the driver type to one of either 'chrome' or 'firefox'.  Leaving
+ empty or not set will use Firefox.  If Firefox is not installed in the
+ expected location, set the driver binary to the full path to the
+ Firefox executable.  Ex `C:\Program Files (x86)\Mozilla Firefox\Firefox.exe`
 
+ You must have installed the proper driver. See the [downloads section here](http://www.seleniumhq.org/download/)
 ## Usage:  
 `python3 ~/squeaky-wheel.py`  
 

--- a/config.json
+++ b/config.json
@@ -16,8 +16,9 @@
     {
         "name": "squeaky-wheel.log"
     },
-    "firefox":
+    "driver":
     {
-        "binary": "C:\\Program Files (x86)\\Mozilla Firefox\\Firefox.exe"
+        "type" : "firefox",
+        "binary" : ""
     }
 }

--- a/config.json
+++ b/config.json
@@ -15,6 +15,9 @@
     "log":
     {
         "name": "squeaky-wheel.log"
+    },
+    "firefox":
+    {
+        "binary": "C:\\Program Files (x86)\\Mozilla Firefox\\Firefox.exe"
     }
-
 }

--- a/squeaky-wheel.py
+++ b/squeaky-wheel.py
@@ -2,16 +2,19 @@ import datetime
 import json
 import time
 import tweepy
+import os.path
 from selenium import webdriver
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import TimeoutException, WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
+CONIFG_FILENAME = "config.json"
 
 class Config(object):
 
-    with open("config.json", "r") as j:
+    with open(CONIFG_FILENAME, "r") as j:
         config = json.load(j)
 
         # set download, upload, isp, twitter api data, and other defaults in config.json
@@ -27,6 +30,12 @@ class Config(object):
         twitter_consumer_secret = config["twitter"]["twitter_consumer_secret"]
 
         log = config["log"]["name"]
+        ff_binary_path = None
+        # If Firefox configuration exists and contains binary configuration
+        if "firefox" in config and "binary" in config["firefox"]:
+            # If the binary is a file somewhere, set it
+            if os.path.isfile(config["firefox"]["binary"]):
+                ff_binary_path = config["firefox"]["binary"]
 
         date = ("Data logged: {:%Y-%b-%d %H:%M:%S}".format(datetime.datetime.now()))
 
@@ -54,50 +63,71 @@ class Log(object):
 
 class SpeedTest(object):
 
-    download = ""
-    upload = ""
-    latency = ""
-    jitter = ""
-    log = Log()
+    def __init__(self, config:Config):
+        self.download = ""
+        self.upload = ""
+        self.latency = ""
+        self.jitter = ""
+        self.log = Log()
+        self.config = config
 
-    def init_driver(self):
-        driver = webdriver.Firefox()
-        driver.wait = WebDriverWait(driver, 5)
-        return driver
+        self.driver = None
+        self.wait = None
+        try:
+            if self.config.ff_binary_path is not None:
+                self.driver = webdriver.Firefox(firefox_binary=FirefoxBinary(config.ff_binary_path))
+            else:
+                self.driver = webdriver.Firefox()
+            self.wait = WebDriverWait(self.driver, 5)
+        except WebDriverException as e:
+            self.log.write_to_log("Driver creation failed {:%Y-%b-%d %H:%M:%S}\n".format(datetime.datetime.now()))
+            self.log.write_to_log("\t" + str(e))
 
-    def run_test(self, driver):
+    def run_test(self):
+        if self.driver is None or self.wait is None:
+            return
 
-        driver.get("https://www.measurementlab.net/p/ndt-ws.html")
+        self.driver.get("https://www.measurementlab.net/p/ndt-ws.html")
 
         try:
-            button = driver.wait.until(EC.element_to_be_clickable(
+            button = self.wait.until(EC.element_to_be_clickable(
                 (By.ID, "start-button")))
             button.click()
 
         except TimeoutException:
             self.log.write_to_log("-- Button not found --")
 
-    def get_data(self):
 
+    def get_data(self):
+        if self.driver is None:
+            return
         try:
-            self.upload = str(driver.find_element_by_id("upload-speed").text)
+            self.upload = str(self.driver.find_element_by_id("upload-speed").text)
         except TimeoutException:
             self.log.write_to_log("-- upload not found --")
 
         try:
-            self.download = str(driver.find_element_by_id("download-speed").text)
+            self.download = str(self.driver.find_element_by_id("download-speed").text)
         except TimeoutException:
             self.log.write_to_log("-- download not found --")
 
         try:
-            self.latency = driver.find_element_by_id("latency").text
+            self.latency = self.driver.find_element_by_id("latency").text
         except TimeoutException:
             self.log.write_to_log("-- latency not found --")
 
         try:
-            self.jitter = driver.find_element_by_id("jitter").text
+            self.jitter = self.driver.find_element_by_id("jitter").text
         except TimeoutException:
             self.log.write_to_log("-- jitter not found --")
+
+    def __del__(self):
+        if self.driver is not None:
+            self.driver.quit()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.driver is not None:
+            self.driver.quit()
 
 
 class Twitter(object):
@@ -127,6 +157,12 @@ class Twitter(object):
 
         speedtest_download = speedtest.download
         speedtest_upload = speedtest.upload
+
+        # If the driver creation failed, these will be empty strings
+        if speedtest_download == "" or speedtest_upload == "":
+            self.log.write_to_log("Speed test values invalid\n")
+            self.log.write_to_log("Down {} : Up {}\n".format(speedtest_download, speedtest_upload))
+            return
 
         if (float(speedtest_download) < config_download * margin or
                 float(speedtest_upload) < config_upload * margin):
@@ -163,12 +199,14 @@ class Twitter(object):
 
 
 if __name__ == "__main__":
-    speedtest = SpeedTest()
-    driver = speedtest.init_driver()
-    speedtest.run_test(driver)
+    # Parse the configuration JSON file
+    config_data = Config()
+    # Create SpeedTest
+    speedtest = SpeedTest(config_data)
+    # Run test
+    speedtest.run_test()
     # instead of sleep could set a driver.wait
     time.sleep(35)
     speedtest.get_data()
-    driver.quit()
     twitter = Twitter()
     twitter.test_results()


### PR DESCRIPTION
The pull request allows a user to configure which driver Selenium uses and to set the Firefox executable path.  This allows non-standard or different installation, like portable Firefox or Windows 64 bit installations to work, as well as choosing to use Chrome.  The user must have installed the proper driver and have it available on the PATH.

This resolves issue #2 

Tested in Chrome 55 with chromedriver 2.26.  Tested in Firefox 50.1.0 with geckodriver 0.11.1.  Not tested with a Windows 32 bit environment (anybody?)